### PR TITLE
WHEEL_ENCODER: Add wheel encoder driver - Pending hardware test

### DIFF
--- a/Architecture/HardwareAbstractions/I_WheelEncoder.h
+++ b/Architecture/HardwareAbstractions/I_WheelEncoder.h
@@ -1,0 +1,27 @@
+#ifndef I_WHEELENCODER_H
+#define I_WHEELENCODER_H
+
+#include "types.h"
+
+typedef struct _WheelEncoderApi_t WheelEncoderApi_t;
+
+typedef struct
+{
+	const WheelEncoderApi_t *api;
+} I_WheelEncoder_t;
+
+struct _WheelEncoderApi_t
+{
+	/*
+	 * Gets the angular velocity of a wheel through the wheel encoder
+	 * and the return value is the angular velocity multiplied times 10,000.
+	 *
+	 * @param instance The implementation of the interface
+	 */
+	uint32_t (*GetAngularVelocityInRadiansPerSecondTimes10K)(I_WheelEncoder_t *instance);
+};
+
+#define WheelEncoder_GetAngularVelocityInRadiansPerSecondTimes10K(_instance) \
+        (_instance)->api->GetAngularVelocityInRadiansPerSecondTimes10K(_instance) \
+
+#endif

--- a/Architecture/HardwareConcretions/WheelEncoder.c
+++ b/Architecture/HardwareConcretions/WheelEncoder.c
@@ -1,0 +1,64 @@
+#include "I_Event.h"
+#include "WheelEncoder.h"
+#include "utils.h"
+
+enum
+{
+	MsPerSecond = 1000
+};
+
+static void IncreaseEnconderTicks(void *context, void *args)
+{
+	RECAST(instance, context, WheelEncoder_t *);
+	IGNORE(args);
+
+	instance->encoderTicks++;
+}
+
+static void SampleAngularVelocity(void *context)
+{
+	RECAST(instance, context, WheelEncoder_t *);
+
+	instance->angularVelocityInRadiansPerSecondTimes10K =
+			instance->encoderTicks * instance->radiansPerEncoderHoleOverSamplingPeriodTimes10K;
+
+	instance->encoderTicks = 0;
+}
+
+static uint32_t GetAngularVelocityInRadiansPerSecondTimes10K(I_WheelEncoder_t *_instance)
+{
+	RECAST(instance, _instance, WheelEncoder_t *);
+
+	return instance->angularVelocityInRadiansPerSecondTimes10K;
+}
+
+static const WheelEncoderApi_t api =
+	{ GetAngularVelocityInRadiansPerSecondTimes10K };
+
+void WheelEncoder_Init(
+		WheelEncoder_t *instance,
+		TimerModule_t *timerModule,
+		I_Interrupt_t *encoderInterrupt,
+		uint8_t encoderDiskHoles,
+		TimerTicks_t angularVelocitySamplingRateMs)
+{
+	float twoPi = 6.2831;
+	instance->radiansPerEncoderHoleOverSamplingPeriodTimes10K =
+			(uint32_t)(((twoPi / encoderDiskHoles) / (angularVelocitySamplingRateMs / MsPerSecond)) * 10000);
+
+	instance->interface.api = &api;
+	instance->angularVelocityInRadiansPerSecondTimes10K = 0;
+	instance->encoderTicks = 0;
+
+	EventSubscriber_Synchronous_Init(&instance->interruptSubscriber, IncreaseEnconderTicks, instance);
+	Event_Subscribe(Interrupt_GetOnInterruptEvent(encoderInterrupt), &instance->interruptSubscriber.interface);
+
+	TimerPeriodic_Init(
+			&instance->angularVelocitySamplingTimer,
+			timerModule,
+			angularVelocitySamplingRateMs,
+			SampleAngularVelocity,
+			instance);
+
+	TimerPeriodic_Start(&instance->angularVelocitySamplingTimer);
+}

--- a/Architecture/HardwareConcretions/WheelEncoder.h
+++ b/Architecture/HardwareConcretions/WheelEncoder.h
@@ -1,0 +1,32 @@
+#ifndef WHEELENCODER_H
+#define WHEELENCODER_H
+
+#include "I_WheelEncoder.h"
+#include "I_Interrupt.h"
+#include "EventSubscriber_Synchronous.h"
+#include "TimerPeriodic.h"
+
+typedef struct
+{
+	I_WheelEncoder_t interface;
+	EventSubscriber_Synchronous_t interruptSubscriber;
+	uint32_t encoderTicks;
+	uint32_t angularVelocityInRadiansPerSecondTimes10K;
+	TimerPeriodic_t angularVelocitySamplingTimer;
+	uint32_t radiansPerEncoderHoleOverSamplingPeriodTimes10K;
+} WheelEncoder_t;
+
+
+/*
+ * Initializes an instance of a wheel encoder
+ * @param instance The object
+ * @param encoderInterrupt Interrupt generated when there is an encoder reading
+ */
+void WheelEncoder_Init(
+		WheelEncoder_t *instance,
+		TimerModule_t *timerModule,
+		I_Interrupt_t *encoderInterrupt,
+		uint8_t encoderDiskHoles,
+		TimerTicks_t angularVelocitySamplingRateMs);
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ INC=Architecture/ \
 	Architecture/DataStructures \
 	Architecture/Event \
 	Architecture/HardwareAbstractions \
+	Architecture/HardwareConcretions \
 	Architecture/Timer \
 	Architecture/TimerModule \
 	Architecture/Utilities \
@@ -17,11 +18,13 @@ INC=Architecture/ \
 CPP_SRC=Test/main.cpp \
 		Test/DataStructures/*.cpp \
 		Test/Doubles/*.cpp \
+		Test/HardwareConcretions/*.cpp \
 		Test/Timer/*.cpp
 
 #Add C source files here
 C_SRC=Architecture/DataStructures/*.c \
 	Architecture/Event/*.c \
+	Architecture/HardwareConcretions/*.c \
 	Architecture/Timer/*.c \
 	Architecture/TimerModule/*.c
 

--- a/Test/Doubles/InterruptTestDouble.cpp
+++ b/Test/Doubles/InterruptTestDouble.cpp
@@ -1,0 +1,33 @@
+#include "InterruptTestDouble.h"
+
+extern "C"
+{
+#include "I_Event.h"
+#include "utils.h"
+#include "types.h"
+}
+
+static Event_Synchronous_t onInterrupt;
+
+static I_Event_t * GetOnInterruptEvent(I_Interrupt_t *instance)
+{
+	IGNORE(instance);
+	return &onInterrupt.interface;
+}
+
+static const InterruptApi_t interruptApi =
+	{ GetOnInterruptEvent };
+
+InterruptTestDouble::InterruptTestDouble()
+{
+	this->interrupt.api = &interruptApi;
+	Event_Synchronous_Init(&onInterrupt);
+}
+
+void InterruptTestDouble::GenerateInterrupt(int numberOfTimes)
+{
+	for(int i = 0; i < numberOfTimes; i++)
+	{
+		Event_Publish(&onInterrupt.interface, NULL);
+	}
+}

--- a/Test/Doubles/InterruptTestDouble.h
+++ b/Test/Doubles/InterruptTestDouble.h
@@ -1,0 +1,29 @@
+#ifndef INTERRUPTTESTDOUBLE_H
+#define INTERRUPTTESTDOUBLE_H
+
+extern "C"
+{
+#include "I_Interrupt.h"
+#include "Event_Synchronous.h"
+}
+
+class InterruptTestDouble
+{
+public:
+	/*
+	 * The actual interrupt
+	 */
+	I_Interrupt_t interrupt;
+
+	/*
+	 * Constructor
+	 */
+	InterruptTestDouble();
+
+	/*
+	 * Make interrupt "happen" as many times
+	 */
+	void GenerateInterrupt(int numberOfTimer);
+};
+
+#endif

--- a/Test/HardwareConcretions/WheelEncoderTest.cpp
+++ b/Test/HardwareConcretions/WheelEncoderTest.cpp
@@ -1,0 +1,80 @@
+#include "CppUTest/TestHarness.h"
+#include "TimerModuleTestDouble.h"
+#include "InterruptTestDouble.h"
+
+extern "C"
+{
+#include <stdlib.h>
+#include "WheelEncoder.h"
+#include "types.h"
+}
+
+enum
+{
+	MsPerSecond = 1000
+};
+
+TEST_GROUP(WheelEncoderTests)
+{
+	WheelEncoder_t wheelEncoder;
+	TimerModuleTestDouble timerModuleTestDouble;
+	InterruptTestDouble interruptTestDouble;
+	uint8_t encoderDiskHoles = 20;
+	TimerTicks_t samplingPeriod;
+	uint32_t radiansPerEncoderHoleOverSamplingPeriodTimes10K;
+
+	void setup()
+	{
+		samplingPeriod = 50;
+		float twoPi = 6.2831;
+		radiansPerEncoderHoleOverSamplingPeriodTimes10K =
+				(uint32_t)(((twoPi / encoderDiskHoles) / (samplingPeriod / MsPerSecond)) * 10000);
+		WheelEncoder_Init(
+				&wheelEncoder,
+				timerModuleTestDouble.timerModule,
+				&interruptTestDouble.interrupt,
+				encoderDiskHoles,
+				samplingPeriod);
+	}
+};
+
+TEST(WheelEncoderTests, ShouldGetZeroRadiansPerSecondWhenInterruptHasntPublished)
+{
+	uint32_t angularFreq = WheelEncoder_GetAngularVelocityInRadiansPerSecondTimes10K(&wheelEncoder.interface);
+	CHECK_EQUAL(0, angularFreq);
+}
+
+TEST(WheelEncoderTests, ShoulStillReturnZeroBeforeTheFirstSamplingPeriodElapses)
+{
+	interruptTestDouble.GenerateInterrupt(10);
+	timerModuleTestDouble.ElapseTicks(samplingPeriod - 1);
+	uint32_t angularFreq = WheelEncoder_GetAngularVelocityInRadiansPerSecondTimes10K(&wheelEncoder.interface);
+	CHECK_EQUAL(0, angularFreq);
+}
+
+TEST(WheelEncoderTests, ShouldGetTheAngularVelocityAfterASamplingPeriod)
+{
+	int numberEncoderReadings = 10;
+	interruptTestDouble.GenerateInterrupt(numberEncoderReadings);
+	timerModuleTestDouble.ElapseTicks(samplingPeriod - 1);
+	uint32_t angularFreq = WheelEncoder_GetAngularVelocityInRadiansPerSecondTimes10K(&wheelEncoder.interface);
+	CHECK_EQUAL(0, angularFreq);
+	timerModuleTestDouble.ElapseTicks(1);
+	angularFreq = WheelEncoder_GetAngularVelocityInRadiansPerSecondTimes10K(&wheelEncoder.interface);
+	CHECK_EQUAL(numberEncoderReadings * radiansPerEncoderHoleOverSamplingPeriodTimes10K , angularFreq);
+}
+
+TEST(WheelEncoderTests, ShouldReportZeroVelocityIfNoInterruptsAreRaisedAfterASamplingPeriod)
+{
+	int numberEncoderReadings = 10;
+	interruptTestDouble.GenerateInterrupt(numberEncoderReadings);
+	timerModuleTestDouble.ElapseTicks(samplingPeriod);
+	uint32_t angularFreq = WheelEncoder_GetAngularVelocityInRadiansPerSecondTimes10K(&wheelEncoder.interface);
+	CHECK_EQUAL(numberEncoderReadings * radiansPerEncoderHoleOverSamplingPeriodTimes10K , angularFreq);
+	timerModuleTestDouble.ElapseTicks(samplingPeriod - 1);
+	angularFreq = WheelEncoder_GetAngularVelocityInRadiansPerSecondTimes10K(&wheelEncoder.interface);
+	CHECK_EQUAL(numberEncoderReadings * radiansPerEncoderHoleOverSamplingPeriodTimes10K , angularFreq);
+	timerModuleTestDouble.ElapseTicks(1);
+	angularFreq = WheelEncoder_GetAngularVelocityInRadiansPerSecondTimes10K(&wheelEncoder.interface);
+	CHECK_EQUAL(0 , angularFreq);
+}


### PR DESCRIPTION
Pending hardware test.

Generic wheel encoder driver to get (radians per second)*(10K) so that we don't have to do floating point operations. It takes in an interrupt, which is expected to come in from the actual encoder interrupt.